### PR TITLE
feat(TG3-011): fluxo de morte com animação, overlay de renascimento e fix no floor 4

### DIFF
--- a/scenes/enemies/skeleton.tscn
+++ b/scenes/enemies/skeleton.tscn
@@ -1,12 +1,12 @@
 [gd_scene format=3 uid="uid://brmt17c21m775"]
 
 [ext_resource type="Script" path="res://scripts/enemies/skeleton.gd" id="1_skel"]
-[ext_resource type="Texture2D" uid="uid://bxb6b467vhld4" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Idle.png" id="2_idle"]
-[ext_resource type="Texture2D" uid="uid://c3nm60dohh5cc" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Walk.png" id="3_walk"]
-[ext_resource type="Texture2D" uid="uid://bn48mbow0uwxn" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Hurt.png" id="4_hurt"]
-[ext_resource type="Texture2D" uid="uid://dqe8k0ych5tqm" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Attack1.png" id="5_atk1"]
-[ext_resource type="Texture2D" uid="uid://cdktve31fe0au" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Attack2.png" id="6_atk2"]
-[ext_resource type="Texture2D" uid="uid://lii2wt7od2tg" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Die.png" id="7_die"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Idle.png" id="2_idle"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Walk.png" id="3_walk"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Hurt.png" id="4_hurt"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Attack1.png" id="5_atk1"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Attack2.png" id="6_atk2"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Die.png" id="7_die"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_atk10"]
 atlas = ExtResource("5_atk1")

--- a/scenes/enemies/skeleton_boss.tscn
+++ b/scenes/enemies/skeleton_boss.tscn
@@ -1,12 +1,12 @@
 [gd_scene format=3 uid="uid://vdfv1gnikqp7"]
 
 [ext_resource type="Script" path="res://scripts/enemies/skeleton_boss.gd" id="1_skel"]
-[ext_resource type="Texture2D" uid="uid://bxb6b467vhld4" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Idle.png" id="2_idle"]
-[ext_resource type="Texture2D" uid="uid://c3nm60dohh5cc" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Walk.png" id="3_walk"]
-[ext_resource type="Texture2D" uid="uid://bn48mbow0uwxn" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Hurt.png" id="4_hurt"]
-[ext_resource type="Texture2D" uid="uid://dqe8k0ych5tqm" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Attack1.png" id="5_atk1"]
-[ext_resource type="Texture2D" uid="uid://cdktve31fe0au" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Attack2.png" id="6_atk2"]
-[ext_resource type="Texture2D" uid="uid://lii2wt7od2tg" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Die.png" id="7_die"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Idle.png" id="2_idle"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Walk.png" id="3_walk"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Hurt.png" id="4_hurt"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Attack1.png" id="5_atk1"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Attack2.png" id="6_atk2"]
+[ext_resource type="Texture2D" path="res://assets/sprites/enemies/Skeleton_White/Skeleton_With_VFX/Skeleton_01_White_Die.png" id="7_die"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_atk10"]
 atlas = ExtResource("5_atk1")

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -421,6 +421,56 @@ custom_minimum_size = Vector2(240, 42)
 layout_mode = 2
 text = "Sair do jogo"
 
+[node name="DeathOverlay" type="Control" parent="UI"]
+process_mode = 3
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Backdrop" type="ColorRect" parent="UI/DeathOverlay"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.55)
+
+[node name="MenuPanel" type="PanelContainer" parent="UI/DeathOverlay"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -180.0
+offset_top = -120.0
+offset_right = 180.0
+offset_bottom = 120.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MenuItems" type="VBoxContainer" parent="UI/DeathOverlay/MenuPanel"]
+layout_mode = 2
+theme_override_constants/separation = 14
+
+[node name="DeathLabel" type="Label" parent="UI/DeathOverlay/MenuPanel/MenuItems"]
+custom_minimum_size = Vector2(300, 48)
+layout_mode = 2
+theme_override_font_sizes/font_size = 34
+text = "Você morreu"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="RespawnButton" type="Button" parent="UI/DeathOverlay/MenuPanel/MenuItems"]
+custom_minimum_size = Vector2(240, 46)
+layout_mode = 2
+text = "Renascer"
+
 [node name="PlayerStatusPanel" parent="UI" instance=ExtResource("2_status_panel")]
 
 [node name="Managers" type="Node" parent="." unique_id=1209282052]

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -7,6 +7,8 @@ const INITIAL_MUSIC_VOLUME_LINEAR := 0.5
 @onready var theme_music = $ThemeMusic
 @onready var main_menu = $UI/MainMenu
 @onready var pause_menu = $UI/PauseMenu
+@onready var death_overlay = $UI/DeathOverlay
+@onready var respawn_button = $UI/DeathOverlay/MenuPanel/MenuItems/RespawnButton
 @onready var hud = $UI/HUD
 @onready var main_continue_button = $UI/MainMenu/MenuPanel/MenuItems/ContinueButton
 @onready var music_volume_slider = $UI/MainMenu/MenuPanel/MenuItems/MusicVolumeSlider
@@ -19,6 +21,7 @@ const INITIAL_MUSIC_VOLUME_LINEAR := 0.5
 
 var is_entry_pause_active := false
 var is_status_panel_open := false
+var is_death_overlay_open := false
 
 func _ready():
 	process_mode = Node.PROCESS_MODE_ALWAYS
@@ -34,6 +37,7 @@ func _ready():
 	$UI/PauseMenu/MenuPanel/MenuItems/ResumeButton.pressed.connect(_on_resume_pressed)
 	$UI/PauseMenu/MenuPanel/MenuItems/NewGameButton.pressed.connect(_on_new_game_pressed)
 	$UI/PauseMenu/MenuPanel/MenuItems/QuitButton.pressed.connect(_on_quit_pressed)
+	respawn_button.pressed.connect(_on_respawn_pressed)
 	dev_mode_button.toggled.connect(_on_dev_mode_toggled)
 	dev_mode_button.button_pressed = GameManager.is_dev_mode
 	_update_dev_button_text(GameManager.is_dev_mode)
@@ -42,13 +46,15 @@ func _ready():
 	show_main_menu()
 
 func _process(_delta):
+	_ensure_player_death_signal()
+
 	if Input.is_action_just_pressed("toggle_status_panel") and not main_menu.visible and game.visible and not is_entry_pause_active and not pause_menu.visible:
 		if is_status_panel_open:
 			_close_status_panel()
 		else:
 			_open_status_panel()
 
-	if Input.is_action_just_pressed("ui_cancel") and not main_menu.visible and game.visible and not is_entry_pause_active and not is_status_panel_open:
+	if Input.is_action_just_pressed("ui_cancel") and not main_menu.visible and game.visible and not is_entry_pause_active and not is_status_panel_open and not is_death_overlay_open:
 		if get_tree().paused:
 			resume_game()
 		else:
@@ -66,6 +72,8 @@ func show_main_menu():
 	hud.visible = false
 	main_menu.visible = true
 	pause_menu.visible = false
+	death_overlay.visible = false
+	is_death_overlay_open = false
 
 func start_game():
 	get_tree().paused = false
@@ -73,6 +81,8 @@ func start_game():
 	hud.visible = true
 	main_menu.visible = false
 	pause_menu.visible = false
+	death_overlay.visible = false
+	is_death_overlay_open = false
 
 func pause_game():
 	if is_status_panel_open:
@@ -93,11 +103,37 @@ func _open_status_panel() -> void:
 func _close_status_panel() -> void:
 	is_status_panel_open = false
 	player_status_panel.visible = false
-	if not pause_menu.visible and not main_menu.visible and game.visible and not is_entry_pause_active:
+	if not pause_menu.visible and not main_menu.visible and game.visible and not is_entry_pause_active and not is_death_overlay_open:
 		get_tree().paused = false
 
 func _get_player_node() -> Node:
 	return get_tree().get_first_node_in_group("player")
+
+func _ensure_player_death_signal() -> void:
+	var player := _get_player_node()
+	if player == null:
+		return
+	if player.has_signal("death_sequence_finished"):
+		var callback := Callable(self, "_on_player_death_sequence_finished")
+		if not player.death_sequence_finished.is_connected(callback):
+			player.death_sequence_finished.connect(callback)
+
+func _on_player_death_sequence_finished() -> void:
+	is_death_overlay_open = true
+	if is_status_panel_open:
+		_close_status_panel()
+	pause_menu.visible = false
+	death_overlay.visible = true
+	get_tree().paused = true
+
+func _on_respawn_pressed() -> void:
+	var player := _get_player_node()
+	if player == null or not player.has_method("respawn_to_hub"):
+		return
+	is_death_overlay_open = false
+	death_overlay.visible = false
+	get_tree().paused = false
+	player.respawn_to_hub()
 
 func _on_new_game_pressed():
 	start_game()

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -37,7 +37,7 @@ func _ensure_death_animation() -> void:
 	if not anim.sprite_frames.has_animation("jump"):
 		return
 
-	var jump_frame_count := anim.sprite_frames.get_frame_count("jump")
+	var jump_frame_count: int = anim.sprite_frames.get_frame_count("jump")
 	if jump_frame_count <= 0:
 		return
 
@@ -47,7 +47,7 @@ func _ensure_death_animation() -> void:
 
 	var start_index := maxi(jump_frame_count - 4, 0)
 	for frame_index in range(start_index, jump_frame_count):
-		var frame_texture := anim.sprite_frames.get_frame_texture("jump", frame_index)
+		var frame_texture: Texture2D = anim.sprite_frames.get_frame_texture("jump", frame_index)
 		anim.sprite_frames.add_frame("die", frame_texture, 1.0)
 
 

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -1,4 +1,5 @@
 extends CharacterBody2D
+signal death_sequence_finished
 
 const SWORD_SFX_1 := preload("res://assets/sprites/effect/sound/sword1.mp3")
 const SWORD_SFX_2 := preload("res://assets/sprites/effect/sound/sword2.mp3")
@@ -25,6 +26,29 @@ func _ready():
 	_sword_sfx_player.name = "SwordSfx"
 	_sword_sfx_player.volume_db = -7.0
 	add_child(_sword_sfx_player)
+	_ensure_death_animation()
+
+
+func _ensure_death_animation() -> void:
+	if anim == null or anim.sprite_frames == null:
+		return
+	if anim.sprite_frames.has_animation("die"):
+		return
+	if not anim.sprite_frames.has_animation("jump"):
+		return
+
+	var jump_frame_count := anim.sprite_frames.get_frame_count("jump")
+	if jump_frame_count <= 0:
+		return
+
+	anim.sprite_frames.add_animation("die")
+	anim.sprite_frames.set_animation_loop("die", false)
+	anim.sprite_frames.set_animation_speed("die", 7.0)
+
+	var start_index := maxi(jump_frame_count - 4, 0)
+	for frame_index in range(start_index, jump_frame_count):
+		var frame_texture := anim.sprite_frames.get_frame_texture("jump", frame_index)
+		anim.sprite_frames.add_frame("die", frame_texture, 1.0)
 
 
 func _play_sword_sfx_start() -> void:
@@ -76,9 +100,14 @@ func die():
 	else:
 		await get_tree().create_timer(0.2).timeout
 
+	death_sequence_finished.emit()
+
+func respawn_to_hub() -> void:
+	if not is_dead:
+		return
+
 	PlayerStats.current_health = PlayerStats.max_health
 	GameManager.return_to_hub()
-
 	is_dead = false
 	set_physics_process(true)
 	can_attack = true


### PR DESCRIPTION
## Contexto
Implementa a task [TG3-011] Fluxo de morte com animação + tela de renascimento (#24), e inclui correção observada durante os testes: inimigos não aparecendo no floor 4 por resolução de recursos dos esqueletos.

## O que foi feito
- Fluxo de morte do player sem retorno automático imediato.
- Execução da animação de morte antes de qualquer transição.
- Overlay de morte com mensagem `Você morreu`.
- Botão `Renascer` para confirmação explícita do respawn.
- Bloqueio de input/gameplay do player no estado de morte.
- Respawn para o hub apenas após clique em `Renascer`.
- Ajuste de compatibilidade de tipagem para Godot 4.6 no setup da animação de morte.
- Fix de recursos dos esqueletos/skeleton boss para restaurar inimigos no floor 4.

## Arquivos principais
- `scripts/player/player.gd`
- `scripts/main.gd`
- `scenes/main.tscn`
- `scenes/enemies/skeleton.tscn`
- `scenes/enemies/skeleton_boss.tscn`

## Critérios de pronto atendidos
- [x] Ao morrer, player executa animação de morte antes da transição
- [x] Mensagem `Você morreu` aparece de forma visível
- [x] Botão `Renascer` aparece e funciona
- [x] Jogo não troca de cena automaticamente sem feedback
- [x] Input de combate/movimento fica bloqueado no estado de morte
- [x] Respawn ocorre corretamente após confirmação do jogador

## Observações
- Validado com smoke test local no Godot 4.6 (headless) para garantir carregamento sem erro de script após os ajustes.