### PR TITLE
fix(gameplay): suaviza parada do player, adiciona TAB no inventario e wrap no floor 0

### DIFF
--- a/scripts/core/main.gd
+++ b/scripts/core/main.gd
@@ -37,6 +37,7 @@ var _tracked_boss: Node = null
 func _ready():
 	process_mode = Node.PROCESS_MODE_ALWAYS
 	game.process_mode = Node.PROCESS_MODE_PAUSABLE
+	_ensure_inventory_tab_shortcut()
 	main_continue_button.disabled = not GameManager.has_save_game()
 	$UI/MainMenu/MenuPanel/MenuItems/NewGameButton.pressed.connect(_on_new_game_pressed)
 	$UI/MainMenu/MenuPanel/MenuItems/ContinueButton.pressed.connect(_on_continue_pressed)
@@ -92,6 +93,19 @@ func _process(_delta):
 	floor_label.text = "Andar: %d" % [GameManager.current_floor]
 	_update_boss_music_state()
 	_update_boss_health_ui()
+
+func _ensure_inventory_tab_shortcut() -> void:
+	if not InputMap.has_action("toggle_inventory_panel"):
+		return
+
+	var tab_event := InputEventKey.new()
+	tab_event.physical_keycode = KEY_TAB
+	tab_event.keycode = KEY_TAB
+
+	if InputMap.action_has_event("toggle_inventory_panel", tab_event):
+		return
+
+	InputMap.action_add_event("toggle_inventory_panel", tab_event)
 
 func _update_health_bar() -> void:
 	var max_health: int = max(PlayerStats.max_health, 1)

--- a/scripts/entities/player/player.gd
+++ b/scripts/entities/player/player.gd
@@ -18,6 +18,8 @@ const HEAL_INDICATOR_DURATION := 0.8
 @export var gravity := 900
 @export var jump_force := -400
 @export var attack_cooldown := 1.0
+@export var acceleration := 900.0
+@export var deceleration := 1200.0
 
 @onready var anim = $AnimatedSprite2D
 
@@ -166,7 +168,7 @@ func _physics_process(delta):
 	if is_dead:
 		return
 
-	var direction = Vector2.ZERO
+	var direction: Vector2 = Vector2.ZERO
 
 	if Input.is_action_just_pressed("use_potion"):
 		var previous_health: int = PlayerStats.current_health
@@ -187,10 +189,12 @@ func _physics_process(delta):
 		direction.x -= 1
 
 	if direction.x != 0:
-		facing_direction = sign(direction.x)
+		facing_direction = int(sign(direction.x))
 		anim.flip_h = facing_direction > 0
 
-	velocity.x = direction.x * PlayerStats.get_move_speed(float(speed))
+	var target_velocity_x: float = direction.x * PlayerStats.get_move_speed(float(speed))
+	var blend_rate: float = acceleration if absf(direction.x) > 0.0 else deceleration
+	velocity.x = move_toward(velocity.x, target_velocity_x, blend_rate * delta)
 
 	if Input.is_action_just_pressed("jump") and is_on_floor():
 		velocity.y = jump_force

--- a/scripts/world/floors/floor_00_city.gd
+++ b/scripts/world/floors/floor_00_city.gd
@@ -2,6 +2,7 @@ extends Node2D
 class_name Floor00City
 
 const TOTAL_PORTAL_FLOORS := 10
+const HORIZONTAL_WRAP_MARGIN := 8.0
 const POTION_COST := 15
 const WEAPON_COST := 60
 const RESISTANCE_COLLAR_COST := 400
@@ -67,6 +68,28 @@ func _ready() -> void:
 
 	var close_btn: Button = $PortalUI/PortalPanel/VBox/CloseButton
 	close_btn.pressed.connect(_close_ui)
+
+func _process(_delta: float) -> void:
+	_apply_player_horizontal_wrap()
+
+func _apply_player_horizontal_wrap() -> void:
+	var player := get_tree().get_first_node_in_group("player") as Node2D
+	if player == null:
+		return
+
+	var player_camera := player.get_node_or_null("Camera2D") as Camera2D
+	if player_camera == null:
+		return
+
+	var left_limit := float(player_camera.limit_left)
+	var right_limit := float(player_camera.limit_right)
+	if right_limit <= left_limit:
+		return
+
+	if player.global_position.x < left_limit:
+		player.global_position.x = right_limit - HORIZONTAL_WRAP_MARGIN
+	elif player.global_position.x > right_limit:
+		player.global_position.x = left_limit + HORIZONTAL_WRAP_MARGIN
 
 func _sync_portal_layout_to_sprite() -> void:
 	var portal_sprite: Node2D = _find_portal_sprite()


### PR DESCRIPTION
## Contexto
PR enxuto para corrigir 3 pontos de gameplay/UX no hub e no controle do player, sem carregar o diff histórico maior da branch anterior.

Closes #37
Supersedes #38

## Alterações
- [x] Suavização da parada horizontal do player com desaceleração progressiva (`move_toward`).
- [x] Adição do `Tab` como atalho alternativo para abrir/fechar inventário (mantendo atalho atual).
- [x] Wrap lateral no `floor_00_city`: ao sair por uma borda, reaparece na borda oposta.

## Arquivos alterados
- [x] `scripts/entities/player/player.gd`
- [x] `scripts/core/main.gd`
- [x] `scripts/world/floors/floor_00_city.gd`

## Validação
- [x] Smoke headless do Godot executado.
- [x] Sem erro de parse/load relacionado às mudanças.
- [x] Warning conhecido de encerramento (`ObjectDB instances leaked`) ainda aparece no projeto e não bloqueia execução.